### PR TITLE
Fix/CI config for node tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,38 +2,85 @@ version: 2.1
 orbs: 
   node: circleci/node@5.0.2
 jobs:
-  test-node:
+  setup:
     executor:
       name: node/default
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - deps-{{ checksum "yarn.lock" }}
+            - deps-
       - node/install-packages:
           pkg-manager: yarn
-      - node/test:
-          pkg-manager: yarn
-          matrix:
-            parameters:
-              version:
-                - 10.13.0
-                - 10.24.1
-                - 11.0.0
-                - 11.15.0
-                - 12.0.0
-                - 12.22.12
-                - 13.0.0
-                - 13.14.0
-                - 14.0.0
-                - 14.20.0
-                - 15.0.0
-                - 15.14.0
-                - 16.0.0
-                - 16.16.0
-                - 17.0.0
-                - 17.9.1
-                - 18.0.0
-                - 18.6.0
-          test-results-for: jest
+      - save_cache:
+          key: deps-{{ checksum "yarn.lock" }}
+          paths: 
+            - node_modules
+      - persist_to_workspace:
+          root: .
+          paths:
+            - '*'
+  build:
+    executor:
+      name: node/default
+    steps:
+      - attach_workspace:
+            at: .
+      - run:
+          name: Build lib
+          command: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - 'dist'
+  test-node:
+    executor: node/default
+    parameters:
+      version:
+        type: string
+    steps:
+      - attach_workspace:
+            at: .
+      - node/install:
+          install-yarn: true
+          node-version: << parameters.version >>
+      - run:
+          name: Validate Node version
+          command: echo Testing on node $(node --version)
+      - run:
+          name: Run tests
+          command: yarn test
+        
 workflows:
   test:
     jobs:
-      - test-node
+      - setup
+      - build:
+          requires:
+            - setup
+      - test-node:
+          requires:
+            - build
+          matrix:
+            parameters:
+              version:
+                - "10.14"
+                - "10.24"
+                - "11.15"
+                - "12.0"
+                - "12.13"
+                - "12.22"
+                - "13.14"
+                - "14.0"
+                - "14.15"
+                - "14.19"
+                - "15.0"
+                - "15.14"
+                - "16.0"
+                - "16.13"
+                - "16.16"
+                - "17.0"
+                - "17.9"
+                # - "18.0"
+                # - "18.4"

--- a/tests/node/fs/async.js
+++ b/tests/node/fs/async.js
@@ -328,13 +328,17 @@ module.exports = () =>
     test('opendir', (done) => {
       if (fs.opendir) {
         fs.opendir(testDirPath, (err, dir) => {
+          if (err) {
+            done(err);
+            return;
+          }
           expectCallToMatch({
             family: 'fs',
             method: 'opendir',
             firstArg: testDirPath,
           });
           dir.closeSync();
-          done(err);
+          done();
         });
       } else {
         done();
@@ -362,6 +366,10 @@ module.exports = () =>
 
     test('readdir', (done) => {
       fs.readdir(testDirPath, (err, files) => {
+        if (err) {
+          done(err);
+          return;
+        }
         expect(Array.isArray(files)).toBeTruthy();
         expectCallToMatch({
           family: 'fs',

--- a/tests/node/fs/promises.js
+++ b/tests/node/fs/promises.js
@@ -41,7 +41,7 @@ module.exports = () =>
         firstArg: newTestFilePath,
         fromRoot: true,
       });
-      await fs.rm(newTestFilePath);
+      standardFs.unlinkSync(newTestFilePath);
     });
 
     test('chmod', async () => {
@@ -76,20 +76,22 @@ module.exports = () =>
         secondArg: newTestFilePath,
         fromRoot: true,
       });
-      await fs.rm(newTestFilePath);
+      standardFs.unlinkSync(newTestFilePath);
     });
 
     test('cp', async () => {
-      await fs.cp(testFilePath, newTestFilePath);
-      expect(standardFs.existsSync(newTestFilePath)).toBeTruthy();
-      expectCallToMatch({
-        family: 'fs/promises',
-        method: 'cp',
-        firstArg: testFilePath,
-        secondArg: newTestFilePath,
-        fromRoot: true,
-      });
-      await fs.rm(newTestFilePath);
+      if (fs.cp) {
+        await fs.cp(testFilePath, newTestFilePath);
+        expect(standardFs.existsSync(newTestFilePath)).toBeTruthy();
+        expectCallToMatch({
+          family: 'fs/promises',
+          method: 'cp',
+          firstArg: testFilePath,
+          secondArg: newTestFilePath,
+          fromRoot: true,
+        });
+        standardFs.unlinkSync(newTestFilePath);
+      }
     });
 
     test('lchown', async () => {
@@ -114,14 +116,16 @@ module.exports = () =>
     });
 
     test('lutimes', async () => {
-      await fs.lutimes(testFilePath, testFileStats.atime, testFileStats.mtime);
-      expectCallToMatch({
-        family: 'fs/promises',
-        method: 'lutimes',
-        firstArg: testFilePath,
-        secondArg: testFileStats.atime,
-        fromRoot: true,
-      });
+      if (fs.lutimes) {
+        await fs.lutimes(testFilePath, testFileStats.atime, testFileStats.mtime);
+        expectCallToMatch({
+          family: 'fs/promises',
+          method: 'lutimes',
+          firstArg: testFilePath,
+          secondArg: testFileStats.atime,
+          fromRoot: true,
+        });
+      }
     });
 
     test('link', async () => {
@@ -134,7 +138,7 @@ module.exports = () =>
         secondArg: newTestFilePath,
         fromRoot: true,
       });
-      await fs.rm(newTestFilePath);
+      standardFs.unlinkSync(newTestFilePath);
     });
 
     test('mkdir', async () => {
@@ -146,7 +150,7 @@ module.exports = () =>
         firstArg: newTestDirPath,
         fromRoot: true,
       });
-      await fs.rmdir(newTestDirPath);
+      standardFs.rmdirSync(newTestDirPath);
     });
 
     test('mkdtemp', async () => {
@@ -230,15 +234,17 @@ module.exports = () =>
     });
 
     test('rm', async () => {
-      await fs.cp(testFilePath, newTestFilePath);
-      await fs.rm(newTestFilePath);
-      expectCallToMatch({
-        index: 7,
-        family: 'fs/promises',
-        method: 'rm',
-        firstArg: newTestFilePath,
-        fromRoot: true,
-      });
+      if (fs.rm) {
+        standardFs.copyFileSync(testFilePath, newTestFilePath);
+        await fs.rm(newTestFilePath);
+        expectCallToMatch({
+          index: 1,
+          family: 'fs/promises',
+          method: 'rm',
+          firstArg: newTestFilePath,
+          fromRoot: true,
+        });
+      }
     });
 
     test('stat', async () => {
@@ -261,7 +267,7 @@ module.exports = () =>
         fromRoot: true,
       });
 
-      await fs.rm(newTestFilePath);
+      standardFs.unlinkSync(newTestFilePath);
     });
 
     test('truncate', async () => {
@@ -275,10 +281,10 @@ module.exports = () =>
     });
 
     test('unlink', async () => {
-      await fs.cp(testFilePath, newTestFilePath);
+      standardFs.copyFileSync(testFilePath, newTestFilePath);
       await fs.unlink(newTestFilePath);
       expectCallToMatch({
-        index: 7,
+        index: 1,
         family: 'fs/promises',
         method: 'unlink',
         firstArg: newTestFilePath,
@@ -297,13 +303,15 @@ module.exports = () =>
     });
 
     test('watch', async () => {
-      await fs.watch(testFilePath);
-      expectCallToMatch({
-        family: 'fs/promises',
-        method: 'watch',
-        firstArg: testFilePath,
-        fromRoot: true,
-      });
+      if (fs.watch) {
+        await fs.watch(testFilePath);
+        expectCallToMatch({
+          family: 'fs/promises',
+          method: 'watch',
+          firstArg: testFilePath,
+          fromRoot: true,
+        });
+      }
     });
 
     test('writeFile', async () => {

--- a/tests/node/timers.test.js
+++ b/tests/node/timers.test.js
@@ -63,8 +63,10 @@ describe('timers', () => {
       });
 
       test('setInterval', async () => {
-        await timersPromises.setInterval();
-        expectCallToMatch({family: 'timers/promises', method: 'setInterval', fromRoot: true});
+        if (timersPromises.setInterval) {
+          await timersPromises.setInterval();
+          expectCallToMatch({family: 'timers/promises', method: 'setInterval', fromRoot: true});
+        }
       });
 
       test('setTimeout', async () => {


### PR DESCRIPTION
This fixes the CI config to enable [matrix-style](https://circleci.com/blog/circleci-matrix-jobs/) jobs for running automated tests on Node.js.

ℹ️ Currently using Jest@27.5.1 that supports Node 10+ but does not support Node 18+.