### PR TITLE
feat: add telemetry notice to inspector log output

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -195,6 +195,16 @@ server.on('error', (err) => {
 });
 
 server.on('listening', () => {
-  logger.log(`🐛 Sandworm Inspector`);
+  logger.log(`🪱 Sandworm Inspector`);
+  if (!disableTelemetry) {
+    logger.log(
+      '\x1b[36m%s\x1b[0m',
+      'This inspector instance is contributing to the community permission database  - see https://tinyurl.com/52r4u5sy',
+    );
+    logger.log(
+      '\x1b[36m%s\x1b[0m',
+      'To disable, run the inspector with the "--no-telemetry" option.',
+    );
+  }
   logger.log(`Running at http://localhost:${port}/`);
 });


### PR DESCRIPTION
This PR adds a notice about telemetry to the console output of the inspector.

<img width="842" alt="image" src="https://user-images.githubusercontent.com/5381731/191370441-f7f9a416-7db1-48b0-b2f0-e432b51c369a.png">

Closes #49 